### PR TITLE
Added RPM specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ var/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!rpm/*.spec
 
 # Installer logs
 pip-log.txt

--- a/rpm/gixy.spec
+++ b/rpm/gixy.spec
@@ -1,0 +1,60 @@
+########################################################################################
+
+Summary:        Nginx configuration static analyzer
+Name:           gixy
+Version:        0.1.1
+Release:        0%{?dist}
+License:        MPLv2.0
+Group:          Development/Utilities
+URL:            https://github.com/yandex/gixy
+
+Source:         https://github.com/yandex/%{name}/archive/v%{version}.tar.gz
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildArch:      noarch
+
+BuildRequires:  python-devel python-setuptools
+
+Requires:       python-setuptools python-six >= 1.1.0 python-jinja >= 2.8
+Requires:       python2-cached_property >= 1.2.0 python2-configargparse >= 0.11.0
+Requires:       python-argparse >= 1.4.0 pyparsing >= 1.5.5 python-markupsafe
+
+Provides:       %{name} = %{verion}-%{release}
+
+########################################################################################
+
+%description
+Gixy is a tool to analyze Nginx configuration. The main goal of Gixy is to prevent 
+misconfiguration and automate flaw detection.
+
+########################################################################################
+
+%prep
+%setup -qn %{name}-%{version}
+
+%clean
+rm -rf %{buildroot}
+
+%build
+python setup.py build
+
+%install
+rm -rf %{buildroot}
+python setup.py install --prefix=%{_prefix} \
+                        --root=%{buildroot}
+
+########################################################################################
+
+%files
+%defattr(-,root,root,-)
+%doc LICENSE AUTHORS README.md docs/*
+%{python_sitelib}/*
+%{_bindir}/%{name}
+
+########################################################################################
+
+%changelog
+* Sat Apr 29 2017 Yandex Team <opensource@yandex-team.ru> - 0.1.1-0
+- Initial build
+

--- a/rpm/python-argparse.spec
+++ b/rpm/python-argparse.spec
@@ -1,0 +1,79 @@
+########################################################################################
+
+%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+
+########################################################################################
+
+%define pkg_name    argparse
+%define pkg_version r140
+
+########################################################################################
+
+Summary:        Python command-line parsing library
+Name:           python-argparse
+Version:        1.4.0
+Release:        0%{?dist}
+License:        Python License
+Group:          Development/Libraries
+URL:            https://github.com/ThomasWaldmann/argparse
+
+Source:         https://github.com/ThomasWaldmann/%{pkg_name}/archive/%{pkg_version}.tar.gz
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildArch:      noarch
+
+BuildRequires:  python >= 2.3 python-setuptools
+
+Requires:       python >= 2.3 python-setuptools
+
+Provides:       %{name} = %{verion}-%{release}
+
+########################################################################################
+
+%description
+The argparse module makes it easy to write user friendly command line interfaces.
+
+The program defines what arguments it requires, and argparse will figure out
+how to parse those out of sys.argv. The argparse module also automatically
+generates help and usage messages and issues errors when users give the program
+invalid arguments.
+
+As of Python >= 2.7 and >= 3.2, the argparse module is maintained within the
+Python standard library. For users who still need to support Python < 2.7 or
+< 3.2, it is also provided as a separate package, which tries to stay
+compatible with the module in the standard library, but also supports older
+Python versions.
+
+argparse is licensed under the Python license, for details see LICENSE.txt.
+
+########################################################################################
+
+%prep
+%setup -qn %{pkg_name}-%{pkg_version}
+
+%clean
+rm -rf %{buildroot}
+
+%build
+python setup.py build
+
+%install
+rm -rf %{buildroot}
+python setup.py install --prefix=%{_prefix} \
+                        --single-version-externally-managed -O1 \
+                        --root=%{buildroot}
+
+########################################################################################
+
+%files
+%defattr(-,root,root,-)
+%doc LICENSE.txt NEWS.txt README.txt
+%{python_sitelib}/*
+
+########################################################################################
+
+%changelog
+* Sat Apr 29 2017 Yandex Team <opensource@yandex-team.ru> - 1.4.0-0
+- Initial build
+


### PR DESCRIPTION
Hello,

Would be nice to have an RPM's spec to let your users build and install `gixy` using package manager (such as YUM) instead of PyPI. Unfortunately, I did not find `python-argparse` package in the EPEL, so I decided to put it in the repository too. 