### PR TITLE
Allow processing stdin, file descriptors

### DIFF
--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -151,7 +151,7 @@ def main():
 
     with Gixy(config=config) as yoda:
         if path == '-':
-            with os.fdopen(sys.stdin.fileno(), mode='r') as fdata:
+            with os.fdopen(sys.stdin.fileno(), 'r') as fdata:
                 yoda.audit('<stdin>', fdata, is_stdin=True)
         else:
             with open(path, mode='r') as fdata:

--- a/gixy/parser/raw_parser.py
+++ b/gixy/parser/raw_parser.py
@@ -22,14 +22,11 @@ class RawParser(object):
     """
     A class that parses nginx configuration with pyparsing
     """
-
-    def __init__(self):
-        self._if_fixer = re.compile(r'(if\s.+)\)\)(\s*\{)?$', flags=re.MULTILINE)
-
     def parse(self, data):
         """
         Returns the parsed tree.
         """
+
         return self.script.parseString(data, parseAll=True)
 
     @cached_property

--- a/gixy/parser/raw_parser.py
+++ b/gixy/parser/raw_parser.py
@@ -26,8 +26,11 @@ class RawParser(object):
         """
         Returns the parsed tree.
         """
+        content = data.strip()
+        if not content:
+            return []
 
-        return self.script.parseString(data, parseAll=True)
+        return self.script.parseString(content, parseAll=True)
 
     @cached_property
     def script(self):

--- a/gixy/parser/raw_parser.py
+++ b/gixy/parser/raw_parser.py
@@ -25,17 +25,15 @@ class RawParser(object):
     """
 
     def __init__(self):
-        self._script = None
+        self._if_fixer = re.compile(r'(if\s.+)\)\)(\s*\{)?$', flags=re.MULTILINE)
 
-    def parse(self, file_path):
+    def parse(self, data):
         """
         Returns the parsed tree.
         """
         # Temporary, dirty hack :(
-        content = open(file_path).read()
-        content = re.sub(r'(if\s.+)\)\)(\s*\{)?$', '\\1) )\\2', content, flags=re.MULTILINE)
+        content = self._if_fixer.sub('\\1) )\\2', data)
         return self.script.parseString(content, parseAll=True)
-        # return self.script.parseFile(file_path, parseAll=True)
 
     @cached_property
     def script(self):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@ nose>=1.3.7
 mock>=2.0.0
 coverage>=4.3
 flake8>=3.2
+tox>=2.7.0

--- a/tests/directives/test_block.py
+++ b/tests/directives/test_block.py
@@ -1,17 +1,13 @@
 from nose.tools import assert_equals, assert_is_instance, assert_is_not_none, assert_is_none, assert_true, assert_false
-import mock
-from six import StringIO
-from six.moves import builtins
 from gixy.parser.nginx_parser import NginxParser
 from gixy.directives.block import *
 
 # TODO(buglloc): what about include block?
 
+
 def _get_parsed(config):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        root = NginxParser('/foo/bar', allow_includes=False).parse('/foo/bar')
-        return root.children[0]
+    root = NginxParser(cwd='', allow_includes=False).parse(config)
+    return root.children[0]
 
 
 def test_block():

--- a/tests/directives/test_directive.py
+++ b/tests/directives/test_directive.py
@@ -1,15 +1,11 @@
 from nose.tools import assert_equals, assert_is_instance, assert_false, assert_true
-import mock
-from six import StringIO
-from six.moves import builtins
 from gixy.parser.nginx_parser import NginxParser
 from gixy.directives.directive import *
 
 
 def _get_parsed(config):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        return NginxParser('/foo/bar', allow_includes=False).parse('/foo/bar').children[0]
+    root = NginxParser(cwd='', allow_includes=False).parse(config)
+    return root.children[0]
 
 
 def test_directive():

--- a/tests/parser/test_nginx_parser.py
+++ b/tests/parser/test_nginx_parser.py
@@ -1,16 +1,11 @@
 from nose.tools import assert_is_instance, assert_equal
-import mock
-from six import StringIO
-from six.moves import builtins
 from gixy.parser.nginx_parser import NginxParser
 from gixy.directives.directive import *
 from gixy.directives.block import *
 
 
 def _parse(config):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        return NginxParser('/foo/bar', allow_includes=False).parse('/foo/bar')
+    return NginxParser(cwd='', allow_includes=False).parse(config)
 
 
 def test_directive():

--- a/tests/parser/test_raw_parser.py
+++ b/tests/parser/test_raw_parser.py
@@ -493,7 +493,5 @@ add_header X-Blank-Comment blank;
 
 
 def assert_config(config, expected):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        actual = RawParser().parse('/foo/bar')
-        assert_equals(actual.asList(), expected)
+    actual = RawParser().parse(config)
+    assert_equals(actual.asList(), expected)

--- a/tests/plugins/test_simply.py
+++ b/tests/plugins/test_simply.py
@@ -81,7 +81,7 @@ def yoda_provider(plugin, plugin_options=None):
 def check_configuration(plugin, config_path, test_config):
     plugin_options = parse_plugin_options(config_path)
     with yoda_provider(plugin, plugin_options) as yoda:
-        yoda.audit(config_path)
+        yoda.audit(config_path, open(config_path, mode='r'))
         results = RawFormatter().format(yoda)
 
         assert_equals(len(results), 1, 'Should have one report')
@@ -102,7 +102,7 @@ def check_configuration(plugin, config_path, test_config):
 
 def check_configuration_fp(plugin, config_path, test_config):
     with yoda_provider(plugin) as yoda:
-        yoda.audit(config_path)
+        yoda.audit(config_path, open(config_path, mode='r'))
         results = RawFormatter().format(yoda)
 
         assert_equals(len(results), 0,


### PR DESCRIPTION
Must resolve #32 
Now Gixy can read configuration file form stdin (use `-` as a file path):
```
$ nginx -T | gixy  -
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
[nginx_parser]	INFO	Switched to parse nginx configuration dump.

==================== Results ===================
No issues found.

==================== Summary ===================
Total issues:
    Unspecified: 0
    Low: 0
    Medium: 0
    High: 0
```
Or file descriptor:
```
$ gixy <(nginx -T)
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
[nginx_parser]	INFO	Switched to parse nginx configuration dump.

==================== Results ===================
No issues found.

==================== Summary ===================
Total issues:
    Unspecified: 0
    Low: 0
    Medium: 0
    High: 0

```