### PR TITLE
Allow processing stdin, file descriptors (2)

### DIFF
--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -98,7 +98,7 @@ def main():
     _init_logger(args.debug)
 
     path = os.path.expanduser(args.nginx_file)
-    if not os.path.isfile(path):
+    if path != '-' and not os.path.exists(path):
         sys.stderr.write('Please specify path to Nginx configuration.\n\n')
         parser.print_help()
         sys.exit(1)
@@ -150,7 +150,13 @@ def main():
         config.set_for(name, options)
 
     with Gixy(config=config) as yoda:
-        yoda.audit(path)
+        if path == '-':
+            with os.fdopen(sys.stdin.fileno(), 'r') as fdata:
+                yoda.audit('<stdin>', fdata, is_stdin=True)
+        else:
+            with open(path, mode='r') as fdata:
+                yoda.audit(path, fdata, is_stdin=False)
+
         formatted = formatters()[config.output_format]().format(yoda)
         if args.output_file:
             with open(config.output_file, 'w') as f:

--- a/gixy/parser/raw_parser.py
+++ b/gixy/parser/raw_parser.py
@@ -3,7 +3,7 @@ from cached_property import cached_property
 
 from pyparsing import (
     Literal, Suppress, White, Word, alphanums, Forward, Group, Optional, Combine,
-    Keyword, OneOrMore, ZeroOrMore, Regex, QuotedString, nestedExpr)
+    Keyword, OneOrMore, ZeroOrMore, Regex, QuotedString, nestedExpr, ParseResults)
 
 LOG = logging.getLogger(__name__)
 
@@ -23,16 +23,15 @@ class RawParser(object):
     A class that parses nginx configuration with pyparsing
     """
 
-    def __init__(self):
-        self._script = None
-
-    def parse(self, file_path):
+    def parse(self, data):
         """
         Returns the parsed tree.
         """
-        content = open(file_path).read()
-        return self.script.parseString(content, parseAll=True)
-        # return self.script.parseFile(file_path, parseAll=True)
+        content = data.strip()
+        if not content:
+            return ParseResults()
+
+        return self.script.parseString(data, parseAll=True)
 
     @cached_property
     def script(self):

--- a/tests/directives/test_block.py
+++ b/tests/directives/test_block.py
@@ -1,17 +1,13 @@
 from nose.tools import assert_equals, assert_is_instance, assert_is_not_none, assert_is_none, assert_true, assert_false
-import mock
-from six import StringIO
-from six.moves import builtins
 from gixy.parser.nginx_parser import NginxParser
 from gixy.directives.block import *
 
 # TODO(buglloc): what about include block?
 
+
 def _get_parsed(config):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        root = NginxParser('/foo/bar', allow_includes=False).parse('/foo/bar')
-        return root.children[0]
+    root = NginxParser(cwd='', allow_includes=False).parse(config)
+    return root.children[0]
 
 
 def test_block():

--- a/tests/directives/test_directive.py
+++ b/tests/directives/test_directive.py
@@ -1,15 +1,11 @@
 from nose.tools import assert_equals, assert_is_instance, assert_false, assert_true
-import mock
-from six import StringIO
-from six.moves import builtins
 from gixy.parser.nginx_parser import NginxParser
 from gixy.directives.directive import *
 
 
 def _get_parsed(config):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        return NginxParser('/foo/bar', allow_includes=False).parse('/foo/bar').children[0]
+    root = NginxParser(cwd='', allow_includes=False).parse(config)
+    return root.children[0]
 
 
 def test_directive():

--- a/tests/parser/test_nginx_parser.py
+++ b/tests/parser/test_nginx_parser.py
@@ -1,16 +1,11 @@
 from nose.tools import assert_is_instance, assert_equal
-import mock
-from six import StringIO
-from six.moves import builtins
 from gixy.parser.nginx_parser import NginxParser
 from gixy.directives.directive import *
 from gixy.directives.block import *
 
 
 def _parse(config):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        return NginxParser('/foo/bar', allow_includes=False).parse('/foo/bar')
+    return NginxParser(cwd='', allow_includes=False).parse(config)
 
 
 def test_directive():

--- a/tests/parser/test_raw_parser.py
+++ b/tests/parser/test_raw_parser.py
@@ -497,8 +497,15 @@ add_header X-Blank-Comment blank;
     assert_config(config, expected)
 
 
+def test_empty_config():
+    config = '''
+        '''
+
+    expected = []
+
+    assert_config(config, expected)
+
+
 def assert_config(config, expected):
-    with mock.patch('%s.open' % builtins.__name__) as mock_open:
-        mock_open.return_value = StringIO(config)
-        actual = RawParser().parse('/foo/bar')
-        assert_equals(actual.asList(), expected)
+    actual = RawParser().parse(config)
+    assert_equals(actual.asList(), expected)

--- a/tests/plugins/test_simply.py
+++ b/tests/plugins/test_simply.py
@@ -81,7 +81,7 @@ def yoda_provider(plugin, plugin_options=None):
 def check_configuration(plugin, config_path, test_config):
     plugin_options = parse_plugin_options(config_path)
     with yoda_provider(plugin, plugin_options) as yoda:
-        yoda.audit(config_path)
+        yoda.audit(config_path, open(config_path, mode='r'))
         results = RawFormatter().format(yoda)
 
         assert_equals(len(results), 1, 'Should have one report')
@@ -102,7 +102,7 @@ def check_configuration(plugin, config_path, test_config):
 
 def check_configuration_fp(plugin, config_path, test_config):
     with yoda_provider(plugin) as yoda:
-        yoda.audit(config_path)
+        yoda.audit(config_path, open(config_path, mode='r'))
         results = RawFormatter().format(yoda)
 
         assert_equals(len(results), 0,


### PR DESCRIPTION
Must resolve #32 
Now Gixy can read configuration file form stdin (use `-` as a file path):
```
$ nginx -T | gixy  -
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
[nginx_parser]	INFO	Switched to parse nginx configuration dump.

==================== Results ===================
No issues found.

==================== Summary ===================
Total issues:
    Unspecified: 0
    Low: 0
    Medium: 0
    High: 0
```
Or file descriptor:
```
$ gixy <(nginx -T)
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
[nginx_parser]	INFO	Switched to parse nginx configuration dump.

==================== Results ===================
No issues found.

==================== Summary ===================
Total issues:
    Unspecified: 0
    Low: 0
    Medium: 0
    High: 0

```