### PR TITLE
Fix if parsing (second try)

### DIFF
--- a/gixy/parser/raw_parser.py
+++ b/gixy/parser/raw_parser.py
@@ -135,7 +135,7 @@ class RawParser(object):
 
         hash_block << (
             keyword +
-            Group(OneOrMore(space + variable)) +
+            Group(OneOrMore(space + value)) +
             Group(
                 left_bracket +
                 Optional(OneOrMore(hash_value)) +
@@ -144,7 +144,7 @@ class RawParser(object):
 
         generic_block << (
             keyword +
-            Group(ZeroOrMore(space + variable)) +
+            Group(ZeroOrMore(space + value)) +
             Group(
                 left_bracket +
                 Optional(sub_block) +
@@ -153,7 +153,7 @@ class RawParser(object):
 
         unparsed_block << (
             keyword +
-            Group(ZeroOrMore(space + variable)) +
+            Group(ZeroOrMore(space + value)) +
             nestedExpr(opener="{", closer="}")
         )("unparsed_block")
 

--- a/tests/parser/test_raw_parser.py
+++ b/tests/parser/test_raw_parser.py
@@ -497,6 +497,22 @@ add_header X-Blank-Comment blank;
     assert_config(config, expected)
 
 
+def test_upstream_dot():
+    config = '''
+upstream test.mysite.com {
+    server 127.0.0.1:9009;
+}
+        '''
+
+    expected = [
+        ['upstream', ['test.mysite.com'], [
+            ['server', '127.0.0.1:9009']
+        ]],
+    ]
+
+    assert_config(config, expected)
+
+
 def test_empty_config():
     config = '''
         '''

--- a/tests/parser/test_raw_parser.py
+++ b/tests/parser/test_raw_parser.py
@@ -234,6 +234,8 @@ if ($host ~* (lori|rage2)\.yandex\.(ru|ua|com|com\.tr)) {
 
 if ($request_filename ~* ^.*?/(\d+_)([^/]+)$) {
 }
+
+if ($foo = "BAR") { rewrite ^(.*)$ /bar; }
         '''
 
     expected = [
@@ -262,6 +264,9 @@ if ($request_filename ~* ^.*?/(\d+_)([^/]+)$) {
             ['set', '$x_frame_options', 'ALLOW']
         ]],
         ['if', ['$request_filename', '~*', '^.*?/(\d+_)([^/]+)$'], [
+        ]],
+        ['if', ['$foo', '=', 'BAR'], [
+            ['rewrite', '^(.*)$', '/bar']
         ]]
     ]
 


### PR DESCRIPTION
PR #38 broke parsing a poor formatted `if` directive, e.g.:
```nginx
if ($foo = "BAR") { rewrite ^(.*)$ /bar; }
```

This PR will fix it:)