### PR TITLE
Exclude CR from HTTP Request splitting

### DIFF
--- a/gixy/plugins/http_splitting.py
+++ b/gixy/plugins/http_splitting.py
@@ -28,11 +28,12 @@ class http_splitting(Plugin):
         if not value:
             return
 
+        server_side = directive.name.startswith('proxy_')
         for var in compile_script(value):
             char = ''
             if var.can_contain('\n'):
                 char = '\\n'
-            elif var.can_contain('\r'):
+            elif not server_side and var.can_contain('\r'):
                 char = '\\r'
             else:
                 continue

--- a/tests/plugins/simply/http_splitting/proxy_pass_cr_fp.conf
+++ b/tests/plugins/simply/http_splitting/proxy_pass_cr_fp.conf
@@ -1,0 +1,3 @@
+location ~* ^/test/(.*) {
+    proxy_pass http://10.10.10.10/$1;
+}

--- a/tests/plugins/simply/http_splitting/proxy_pass_lf.conf
+++ b/tests/plugins/simply/http_splitting/proxy_pass_lf.conf
@@ -1,0 +1,3 @@
+location ~* ^/test/([^/]+)/ {
+    proxy_pass http://10.10.10.10/$1;
+}


### PR DESCRIPTION
Only small subsets of servers perceive CR as a request headers delimiter, so we disable them before the appearance of the severity level INFO.
Must resolve #75 