### PR TITLE
Encode input arguments in directive_factory function, fixes #73

### DIFF
--- a/gixy/parser/nginx_parser.py
+++ b/gixy/parser/nginx_parser.py
@@ -76,7 +76,7 @@ class NginxParser(object):
             self.parse_block(children, inst)
             return inst
         else:
-            args = [str(v).strip() for v in parsed_args]
+            args = [str(v.encode("utf-8")).strip() for v in parsed_args]
             return klass(parsed_name, args)
 
     def _get_directive_class(self, parsed_type, parsed_name):


### PR DESCRIPTION
Dear maintainers, referring to issue #73 

We would like to use gixy. Unfortunately, it fails to parse lines containing non-english characters.
Suggested fix works as expected with python v2, however I can't make it work with python v3.
How good or bad is it? Is there any better way?

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en