### PR TITLE
Don't require argparse for Python >= 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'pyparsing>=1.5.5',
         'cached-property>=1.2.0',
-        'argparse>=1.4.0',
+        'argparse>=1.4.0;python_version<"3.2"',
         'six>=1.1.0',
         'Jinja2>=2.8',
         'ConfigArgParse>=0.11.0'


### PR DESCRIPTION
argparse was included in the stdlib of Python in version 3.2.

Signed-off-by: Jelle van der Waa <jelle@vdwaa.nl>