### PR TITLE
Add hint toaliastraversal documentation

### DIFF
--- a/docs/en/plugins/aliastraversal.md
+++ b/docs/en/plugins/aliastraversal.md
@@ -23,3 +23,4 @@ In other words, the incorrect configuration of `alias` could allow an attacker t
 It's pretty simple:
   - you must find all the `alias` directives;
   - make sure that the parent prefixed location ends with directory separator.
+  - or if you want to map a signle file make sure the location starts with a `=`, e.g `=/i.gif` instead of `/i.gif`.


### PR DESCRIPTION
Document on what to do if an alias points to a file and should thus not end with a /