### PR TITLE
Updated Dockerfile for Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:2.7-alpine
+FROM python:alpine
 
 ADD . /src
 
 WORKDIR /src
 
-RUN python2 setup.py install
+RUN python3 setup.py install
 
 ENTRYPOINT ["gixy"]


### PR DESCRIPTION
Changed Dockerfile to use Python2 -> Python3, since [Python2 has been EOLed](https://www.python.org/dev/peps/pep-0373/#id2).