### PR TITLE
Fix pyparsing version due to incompatibility with 3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyparsing>=1.5.5
+pyparsing==2.4.7
 cached-property>=1.2.0
 argparse>=1.4.0
 six>=1.1.0


### PR DESCRIPTION
TL;DR: gixy does not work with latest pyparsing (3.x) versions, it fails with bogus parsing errors like:
> ERROR	Failed to parse config "/etc/nginx/nginx.conf": char 5 (line:1, col:6)

or similar.