### PR TITLE
Use stdlib functools.cached_property in Python 3.8+

### DIFF
--- a/gixy/core/regexp.py
+++ b/gixy/core/regexp.py
@@ -3,7 +3,11 @@ import logging
 import re
 import random
 import itertools
-from cached_property import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 import gixy.core.sre_parse.sre_parse as sre_parse
 

--- a/gixy/directives/block.py
+++ b/gixy/directives/block.py
@@ -1,4 +1,7 @@
-from cached_property import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 from gixy.directives.directive import Directive
 from gixy.core.variable import Variable

--- a/gixy/parser/raw_parser.py
+++ b/gixy/parser/raw_parser.py
@@ -1,7 +1,11 @@
 import logging
 import codecs
 import six
-from cached_property import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 from pyparsing import (
     Literal, Suppress, White, Word, alphanums, Forward, Group, Optional, Combine,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyparsing>=1.5.5
-cached-property>=1.2.0
+cached-property>=1.2.0;python_version<"3.8"
 argparse>=1.4.0
 six>=1.1.0
 Jinja2>=2.8

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/yandex/gixy',
     install_requires=[
         'pyparsing>=1.5.5',
-        'cached-property>=1.2.0',
+        'cached-property>=1.2.0;python_version<"3.8"',
         'argparse>=1.4.0;python_version<"3.2"',
         'six>=1.1.0',
         'Jinja2>=2.8',


### PR DESCRIPTION
Python 3.8+ has a functools.cached_property decorator in stdlib.  Use it
in place of third-party cached_property when available.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en