### PR TITLE
Lock pyparsing to 2.4.7 Maximum

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyparsing>=1.5.5
+pyparsing>=1.5.5,<=2.4.7
 cached-property>=1.2.0
 argparse>=1.4.0
 six>=1.1.0


### PR DESCRIPTION
I am writing a nginx/wsgi management tool called `pynx` that uses your excellent tools to parse the nginx config files. While testing on one of my production servers it failed with the error `Skip unparseable block: "server"`. I disovered that the server failing was using `pyparsing`  3.0.9. I was able to fix this by downgrading to the last stable 2.x release of 2.4.7.

Note: Not sure why github is showing me changing the last line in requirements.txt. Let me know if this is a problem and I'll dig into why. I suspect its an EOL character change.